### PR TITLE
Cleanup how item logistics handles null/empty values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     }
   ],
   "require": {
-    "php": ">=5.6"
+    "php"         : ">=5.6",
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/src/Date.php
+++ b/src/Date.php
@@ -24,6 +24,6 @@ class Date
 
     public static function isEmpty($date)
     {
-        return empty($date) || '0000-00-00' === substr($date, 0, 10);
+        return mb_strlen($date) === 0 || '0000-00-00' === substr($date, 0, 10);
     }
 }

--- a/src/Item.php
+++ b/src/Item.php
@@ -253,38 +253,41 @@ XML;
      * Set the item logistics.
      * Corresponding attributes will also be added to the product attributes group too.
      *
-     * @param $legacyDistributorId
-     * @param $mdsFamId
-     * @param $vendorStockId
+     * @param null $legacyDistributorId
+     * @param null $mdsFamId
+     * @param null $vendorStockId
      */
-    public function setItemLogistics($legacyDistributorId, $mdsFamId, $vendorStockId)
+    public function setItemLogistics($legacyDistributorId = null, $mdsfamId = null, $vendorStockId = null)
     {
-        $itemLogistics = [
+        $itemLogisticsParams = [
             'legacyDistributorId' => $legacyDistributorId,
-            'mdsFamId'            => $mdsFamId,
+            'mdsfamId'            => $mdsfamId,
             'vendorStockId'       => $vendorStockId,
         ];
 
         // The name to use when adding them to the product attributes group.
         $attributeLookup = [
             'legacyDistributorId' => 'supplier_number',
-            'mdsFamId'            => 'mds_fam_id',
+            'mdsfamId'            => 'mds_fam_id',
             'vendorStockId'       => 'supplier_stock_number',
         ];
 
+        $itemLogisticsElements   = [];
         $itemLogisticsAttributes = [];
 
-        foreach ($itemLogistics as $key => $value) {
+        foreach ($itemLogisticsParams as $key => $value) {
+            $itemLogisticsElements[$key] = '';
+
+            if (! empty($value)) {
+                $itemLogisticsElements[$key] = '<' . $key . '>' . Xml::escape($value) . '</' . $key . '>';
+            }
+
             if (isset($attributeLookup[$key])) {
                 $itemLogisticsAttributes[$attributeLookup[$key]] = (string) $value;
             }
         }
 
         $this->addAttributes('Product', $itemLogisticsAttributes);
-
-        $itemLogistics = array_map(function($value) {
-            return Xml::escape((string) $value);
-        }, $itemLogistics);
 
         $this->itemLogistics = <<< XML
 <!-- START: Required Dummy Values -->
@@ -340,7 +343,7 @@ XML;
 <!-- END: Required Dummy Values -->
 <shipNodes>
     <shipNode>
-        <legacyDistributorId>{$itemLogistics['legacyDistributorId']}</legacyDistributorId>
+        {$itemLogisticsElements['legacyDistributorId']}
         <!-- START: Required Dummy Values -->
         <itemShipNodeStatus>str1234</itemShipNodeStatus>
         <preOrderMaxQty>
@@ -367,8 +370,8 @@ XML;
         <!-- END: Required Dummy Values -->
         <itemShipNodeSupplies>
             <itemShipNodeSupply>
-                <mdsfamId>{$itemLogistics['mdsFamId']}</mdsfamId>
-                <vendorStockId>{$itemLogistics['vendorStockId']}</vendorStockId>
+                {$itemLogisticsElements['mdsfamId']}
+                {$itemLogisticsElements['vendorStockId']}
             </itemShipNodeSupply>
         </itemShipNodeSupplies>
     </shipNode>

--- a/src/Item.php
+++ b/src/Item.php
@@ -149,7 +149,7 @@ XML;
      */
     public function setBrand($brand)
     {
-        if (! empty($brand)) {
+        if (mb_strlen($brand) > 0) {
             $this->brand = '<brand>' . Xml::escape($brand) . '</brand>';
         }
     }
@@ -278,7 +278,7 @@ XML;
         foreach ($itemLogisticsParams as $key => $value) {
             $itemLogisticsElements[$key] = '';
 
-            if (! empty($value)) {
+            if (mb_strlen($value) > 0) {
                 $itemLogisticsElements[$key] = '<' . $key . '>' . Xml::escape($value) . '</' . $key . '>';
             }
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -276,13 +276,15 @@ XML;
         $itemLogisticsAttributes = [];
 
         foreach ($itemLogisticsParams as $key => $value) {
+            $hasValue = mb_strlen($value) > 0;
+
             $itemLogisticsElements[$key] = '';
 
-            if (mb_strlen($value) > 0) {
+            if ($hasValue) {
                 $itemLogisticsElements[$key] = '<' . $key . '>' . Xml::escape($value) . '</' . $key . '>';
             }
 
-            if (isset($attributeLookup[$key])) {
+            if ($hasValue && isset($attributeLookup[$key])) {
                 $itemLogisticsAttributes[$attributeLookup[$key]] = (string) $value;
             }
         }


### PR DESCRIPTION
The new `setItemLogistics()` function should not require any parameters (at least in the short term). I've cleaned up the internals so the corresponding elements only get created if a value was passed. I also corrected msFamId to msfamId, which matches the Pangaea element name, as it's a little confusing to have it cased differently.