### PR TITLE
Refactored item statuses into separate methods with validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ PHP library for working with Pangaea platform
 
 Produces data feeds for Walmarts global e-commerce platform, Pangaea:
 
-- product items as XML
-- category taxonomy as JSON
+- Product items as XML
+- Category taxonomy as JSON
 
 XML files are automatically validated against the included XSD schema files.
+
+
+Requirements
+---
+
+This library requires PHP 5.6+ and the [multibyte string extension](http://php.net/manual/en/book.mbstring.php) to be installed.
 
 
 Install
@@ -20,6 +26,7 @@ Via Composer:
 ``` bash
 $ composer require fusionspim/pangaea-php-sdk
 ```
+
 
 Usage
 ---

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -8,7 +8,18 @@ namespace Pangaea;
  */
 class Feed
 {
+    /**
+     * Timestamp
+     *
+     * @var string
+     */
     private $timestamp;
+
+    /**
+     * Items XML
+     *
+     * @var string
+     */
     private $items;
 
     /**

--- a/src/Item.php
+++ b/src/Item.php
@@ -4,7 +4,7 @@ namespace Pangaea;
 class Item
 {
     /**
-     * Specification Default End Date (as specified by Walmart).
+     * Default End Date (as specified by Walmart).
      *
      * @const
      */
@@ -49,16 +49,84 @@ class Item
     ];
 
     /**
-     * Internals.
+     * SKU
      *
      * @var mixed
      */
-    private $sku, $upc, $title, $shortDescription, $longDescription, $taxCode, $assets, $attributes, $brand, $itemLogistics;
-
-    private $shipping = '';
+    private $sku;
 
     /**
-     * Offer statuses.
+     * UPC
+     *
+     * @var mixed
+     */
+    private $upc;
+
+    /**
+     * Title
+     *
+     * @var mixed
+     */
+    private $title;
+
+    /**
+     * Short Description
+     *
+     * @var mixed
+     */
+    private $shortDescription;
+
+    /**
+     * Long Description
+     *
+     * @var mixed
+     */
+    private $longDescription;
+
+    /**
+     * Tax Code
+     *
+     * @var mixed
+     */
+    private $taxCode;
+
+    /**
+     * Assets
+     *
+     * @var mixed
+     */
+    private $assets;
+
+    /**
+     * Attributes
+     *
+     * @var array
+     */
+    private $attributes = [];
+
+    /**
+     * Brand
+     *
+     * @var mixed
+     */
+    private $brand;
+
+    /**
+     * Item Logistics XML
+     *
+     * @var mixed
+     */
+    private $itemLogistics;
+
+    /**
+     * Shipping Dimensions XML
+     *
+     * @var string
+     */
+    private $shipping;
+
+    /**
+     * Publish and Lifecycle Statuses.
      *
      * @var array
      */

--- a/src/Item.php
+++ b/src/Item.php
@@ -130,7 +130,7 @@ class Item
      */
     public function setPublishStatus($status)
     {
-        $status = strtoupper($status);
+        $status = mb_strtoupper($status);
 
         if (! in_array($status, static::PUBLISHED_STATUSES)) {
             throw new PangaeaException(sprintf('Invalid publish status "%s"', $status));
@@ -148,7 +148,7 @@ class Item
      */
     public function setLifecycleStatus($status)
     {
-        $status = strtoupper($status);
+        $status = mb_strtoupper($status);
 
         if (! in_array($status, static::LIFECYCLE_STATUSES)) {
             throw new PangaeaException(sprintf('Invalid lifecycle status "%s"', $status));

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -25,7 +25,7 @@ class Taxonomy
      * @return string
      * @throws PangaeaException
      */
-    protected function build()
+    private function build()
     {
         $json = json_encode($this->items, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
 

--- a/tests/ItemsTest.php
+++ b/tests/ItemsTest.php
@@ -75,7 +75,8 @@ class ItemsTest extends AbstractTest
     }
 
     /**
-     * @expectedException \Pangaea\PangaeaException
+     * @expectedException              \Pangaea\PangaeaException
+     * @expectedExceptionMessageRegExp /Invalid publish status ".*"/
      */
     public function testInvalidPublishStatusException()
     {
@@ -83,7 +84,8 @@ class ItemsTest extends AbstractTest
     }
 
     /**
-     * @expectedException \Pangaea\PangaeaException
+     * @expectedException              \Pangaea\PangaeaException
+     * @expectedExceptionMessageRegExp /Invalid lifecycle status ".*"/
      */
     public function testInvalidLifecycleStatusException()
     {

--- a/tests/ItemsTest.php
+++ b/tests/ItemsTest.php
@@ -20,7 +20,8 @@ class ItemsTest extends AbstractTest
         $item->setDescriptions('Short description', 'Longer description about the item...');
         $item->setTaxCode(20);
         $item->setDates('2015-01-01', '2025-01-01');
-        $item->setStatus(true, false);
+        $item->setPublishStatus('UNPUBLISHED');
+        $item->setLifecycleStatus('ACTIVE');
         $item->setDimensions(50, 1.5, 74.67, 'CM');
         $item->setWeight(0.5, 'G');
         $item->setPricing(14.99, 9.99, 12.49, '2015-01-01');
@@ -56,11 +57,13 @@ class ItemsTest extends AbstractTest
         $feed->addItem($item);
 
         $this->feed = $feed;
+        $this->item = $item;
     }
 
     public function tearDown()
     {
         $this->feed = null;
+        $this->item = null;
     }
 
     public function testItemsXml()
@@ -69,6 +72,22 @@ class ItemsTest extends AbstractTest
         $outputXml = $this->feed->getXml();
 
         $this->assertXmlStringEqualsXmlString($sampleXml, $outputXml);
+    }
+
+    /**
+     * @expectedException \Pangaea\PangaeaException
+     */
+    public function testInvalidPublishStatusException()
+    {
+        $this->item->setPublishStatus('FOOBAR');
+    }
+
+    /**
+     * @expectedException \Pangaea\PangaeaException
+     */
+    public function testInvalidLifecycleStatusException()
+    {
+        $this->item->setLifecycleStatus('FOOBAR');
     }
 
     public function testSaveItemsXml()


### PR DESCRIPTION
https://trello.com/c/Q6HnRpgs/

I've split the status methods out, as it doesn't really make sense that they're set together. I've also changed the methods so that they only take valid statuses (it's Fusions' job to work out which product status maps to which Pangaea status). And I've added in some validation to ensure that the values given are correct, plus more tests, docblocks etc.