### PR TITLE
Allow raw descriptions to be set

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -248,13 +248,21 @@ class Item implements RenderableInterface
     }
 
     /**
+     * Set the descriptions (short and long).
+     *
      * @param $short
      * @param $long
+     * @param $raw
      */
-    public function setDescriptions($short, $long)
+    public function setDescriptions($short, $long, $raw = false)
     {
-        $this->shortDescription = Xml::escape($short);
-        $this->longDescription  = Xml::escape($long);
+        if (! $raw) {
+            $short = Xml::escape($short);
+            $long  = Xml::escape($long);
+        }
+
+        $this->shortDescription = $short;
+        $this->longDescription  = $long;
     }
 
     /**

--- a/tests/ItemsTest.php
+++ b/tests/ItemsTest.php
@@ -49,7 +49,7 @@ class ItemsTest extends PHPUnit_Framework_TestCase
             $item = new Item($variation['sku'], $variation['upc']);
             $item->setTitle('Sample item');
             $item->setBrand('Brandtastic');
-            $item->setDescriptions('Short description', 'Longer description about the item...');
+            $item->setDescriptions('Short description', 'Longer description about the item... &amp;bull;', true);
             $item->setTaxCode(20);
             $item->setDates('2015-01-01', '2025-01-01');
             $item->setPublishStatus('UNPUBLISHED');

--- a/tests/fixtures/items.xml
+++ b/tests/fixtures/items.xml
@@ -17,7 +17,7 @@
       <sku>SKU123</sku>
       <productTitle>Sample item</productTitle>
       <productShortDescription>Short description</productShortDescription>
-      <productLongDescription>Longer description about the item...</productLongDescription>
+      <productLongDescription>Longer description about the item... &amp;bull;</productLongDescription>
       <productTaxCode>2,000.00</productTaxCode>
       <ProductIds>
         <ProductId>
@@ -509,7 +509,7 @@
       <sku>SKU456</sku>
       <productTitle>Sample item</productTitle>
       <productShortDescription>Short description</productShortDescription>
-      <productLongDescription>Longer description about the item...</productLongDescription>
+      <productLongDescription>Longer description about the item... &amp;bull;</productLongDescription>
       <productTaxCode>2,000.00</productTaxCode>
       <ProductIds>
         <ProductId>
@@ -1001,7 +1001,7 @@
       <sku>SKU787</sku>
       <productTitle>Sample item</productTitle>
       <productShortDescription>Short description</productShortDescription>
-      <productLongDescription>Longer description about the item...</productLongDescription>
+      <productLongDescription>Longer description about the item... &amp;bull;</productLongDescription>
       <productTaxCode>2,000.00</productTaxCode>
       <ProductIds>
         <ProductId>


### PR DESCRIPTION
This allows the description to be added completely unescaped. This is a workaround for now, but a more flexible solution is also in the works.