### PR TITLE
Tweak item logistics product attribute behaviour

### DIFF
--- a/src/Item/ItemLogistics.php
+++ b/src/Item/ItemLogistics.php
@@ -272,8 +272,10 @@ class ItemLogistics implements RenderableInterface
         $attributes = [];
 
         foreach ($map as $name => $value) {
-            if (! is_null($value) && mb_strlen($value) > 0) {
-                $attributes[] = new NameValueAttribute($name, $value);
+            $attribute = new NameValueAttribute($name, $value);
+
+            if (! $attribute->isEmpty()) {
+                $attributes[] = $attribute;
             }
         }
 

--- a/src/Item/ItemLogistics.php
+++ b/src/Item/ItemLogistics.php
@@ -263,11 +263,21 @@ class ItemLogistics implements RenderableInterface
      */
     public function getProductAttributes()
     {
-        return [
-            new NameValueAttribute('supplier_number', $this->legacyDistributorId),
-            new NameValueAttribute('mds_fam_id', $this->shipNodeSupply['mdsfamId']),
-            new NameValueAttribute('supplier_stock_number', $this->shipNodeSupply['vendorStockId']),
+        $map = [
+            'supplier_number'       => $this->legacyDistributorId,
+            'mds_fam_id'            => $this->shipNodeSupply['mdsfamId'],
+            'supplier_stock_number' => $this->shipNodeSupply['vendorStockId'],
         ];
+
+        $attributes = [];
+
+        foreach ($map as $name => $value) {
+            if (! is_null($value) && mb_strlen($value) > 0) {
+                $attributes[] = new NameValueAttribute($name, $value);
+            }
+        }
+
+        return $attributes;
     }
 
     /**

--- a/src/Item/ItemLogistics.php
+++ b/src/Item/ItemLogistics.php
@@ -257,7 +257,7 @@ class ItemLogistics implements RenderableInterface
     }
 
     /**
-     * Get an array of attribues that belong in the item's product attributes element.
+     * Get an array of attributes that belong in the item's product attributes element.
      *
      * @return array
      */

--- a/src/Item/ItemLogistics.php
+++ b/src/Item/ItemLogistics.php
@@ -258,6 +258,7 @@ class ItemLogistics implements RenderableInterface
 
     /**
      * Get an array of attributes that belong in the item's product attributes element.
+     * Note: Attributes are only created and returned if there's a non-empty value.
      *
      * @return array
      */

--- a/tests/Item/ItemLogisticsTest.php
+++ b/tests/Item/ItemLogisticsTest.php
@@ -14,9 +14,21 @@ class ItemLogisticsTest extends \PHPUnit_Framework_TestCase
 
         $attributes = $itemLogistics->getProductAttributes();
 
-        $this->assertEquals(12345,    $attributes[0]->getValue()[0]);
+        $this->assertCount(3, $attributes);
+        $this->assertEquals(12345, $attributes[0]->getValue()[0]);
         $this->assertEquals(12345678, $attributes[1]->getValue()[0]);
-        $this->assertEquals(123456,   $attributes[2]->getValue()[0]);
+        $this->assertEquals(123456, $attributes[2]->getValue()[0]);
+    }
+
+    public function testItemLogisticsPartialProductAttributes()
+    {
+        $itemLogistics = new ItemLogistics;
+        $itemLogistics->setLegacyDistributorId(12345);
+
+        $attributes = $itemLogistics->getProductAttributes();
+
+        $this->assertCount(1, $attributes);
+        $this->assertEquals(12345, $attributes[0]->getValue()[0]);
     }
 
     public function testItemLogisticsBlankProductAttributes()

--- a/tests/Item/ItemLogisticsTest.php
+++ b/tests/Item/ItemLogisticsTest.php
@@ -6,6 +6,25 @@ use \Pangaea\Item\ItemLogistics;
 
 class ItemLogisticsTest extends \PHPUnit_Framework_TestCase
 {
+    public function testItemLogisticsProductAttributes()
+    {
+        $itemLogistics = new ItemLogistics;
+        $itemLogistics->setLegacyDistributorId(12345);
+        $itemLogistics->setShipNodeSupply(12345678, 123456);
+
+        $attributes = $itemLogistics->getProductAttributes();
+
+        $this->assertEquals(12345,    $attributes[0]->getValue()[0]);
+        $this->assertEquals(12345678, $attributes[1]->getValue()[0]);
+        $this->assertEquals(123456,   $attributes[2]->getValue()[0]);
+    }
+
+    public function testItemLogisticsBlankProductAttributes()
+    {
+        $itemLogistics = new ItemLogistics;
+        $this->assertEquals([], $itemLogistics->getProductAttributes());
+    }
+
     /**
      * @expectedException        \Pangaea\PangaeaException
      * @expectedExceptionMessage Unit cost currency cannot be blank


### PR DESCRIPTION
A product attribute should only be returned if it does not have an empty value. Added extra unit tests to ensure behaviour too.