### PR TITLE
Don't immediately cast item logistics internals to strings

### DIFF
--- a/src/Item/ItemLogistics.php
+++ b/src/Item/ItemLogistics.php
@@ -259,6 +259,7 @@ class ItemLogistics implements RenderableInterface
     /**
      * Get an array of attributes that belong in the item's product attributes element.
      * Note: Attributes are only created and returned if there's a non-empty value.
+     *       Attributes are to be of type STRING if they're not empty/null.
      *
      * @return array
      */
@@ -276,6 +277,8 @@ class ItemLogistics implements RenderableInterface
             $attribute = new NameValueAttribute($name, $value);
 
             if (! $attribute->isEmpty()) {
+                $attribute->setValue((string) $value);
+
                 $attributes[] = $attribute;
             }
         }

--- a/src/Item/ItemLogistics.php
+++ b/src/Item/ItemLogistics.php
@@ -231,7 +231,7 @@ class ItemLogistics implements RenderableInterface
         }
 
         $this->unitCost['amount']   = (float) $amount;
-        $this->unitCost['currency'] = (string) $currency;
+        $this->unitCost['currency'] = $currency;
     }
 
     /**
@@ -241,7 +241,7 @@ class ItemLogistics implements RenderableInterface
      */
     public function setLegacyDistributorId($legacyDistributorId)
     {
-        $this->legacyDistributorId = (string) $legacyDistributorId;
+        $this->legacyDistributorId = $legacyDistributorId;
     }
 
     /**
@@ -252,8 +252,8 @@ class ItemLogistics implements RenderableInterface
      */
     public function setShipNodeSupply($mdsfamId, $vendorStockId)
     {
-        $this->shipNodeSupply['mdsfamId']      = (string) $mdsfamId;
-        $this->shipNodeSupply['vendorStockId'] = (string) $vendorStockId;
+        $this->shipNodeSupply['mdsfamId']      = $mdsfamId;
+        $this->shipNodeSupply['vendorStockId'] = $vendorStockId;
     }
 
     /**

--- a/tests/Item/ItemLogisticsTest.php
+++ b/tests/Item/ItemLogisticsTest.php
@@ -15,9 +15,9 @@ class ItemLogisticsTest extends \PHPUnit_Framework_TestCase
         $attributes = $itemLogistics->getProductAttributes();
 
         $this->assertCount(3, $attributes);
-        $this->assertEquals(12345, $attributes[0]->getValue()[0]);
-        $this->assertEquals(12345678, $attributes[1]->getValue()[0]);
-        $this->assertEquals(123456, $attributes[2]->getValue()[0]);
+        $this->assertEquals('12345', $attributes[0]->getValue()[0]);
+        $this->assertEquals('12345678', $attributes[1]->getValue()[0]);
+        $this->assertEquals('123456', $attributes[2]->getValue()[0]);
     }
 
     public function testItemLogisticsPartialProductAttributes()
@@ -28,7 +28,7 @@ class ItemLogisticsTest extends \PHPUnit_Framework_TestCase
         $attributes = $itemLogistics->getProductAttributes();
 
         $this->assertCount(1, $attributes);
-        $this->assertEquals(12345, $attributes[0]->getValue()[0]);
+        $this->assertEquals('12345', $attributes[0]->getValue()[0]);
     }
 
     public function testItemLogisticsBlankProductAttributes()


### PR DESCRIPTION
As they could be another type (e.g. integer). They only need to be casted as strings when they're converted into `NameValueAttributes` inside `getProductAttributes()` so they come out as type `STRING` in the XML (confirmed by client in previous work).

Based on [this test](https://github.com/fusionspim/pangaea-php-sdk/blob/master/tests/ItemsTest.php#L69), it seems like should be possible (@weshooper ?) to set an empty string as a value and have it appear in the XML?